### PR TITLE
Fix erroneous code block

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,7 +22,5 @@ Materials in this document are under construction; the contents and order of the
 ```
 
 <div style="text-align: center", font-size: 1.2em>
-
-    Freek Pols, Luuk Fröling, Robert Lanzafame, Kirstie Whitaker
-
+Freek Pols, Luuk Fröling, Robert Lanzafame, Kirstie Whitaker
 </div>


### PR DESCRIPTION
Closes #17 

In (some?) Markdown processes indenting a paragraph means the text is treated as literal and interpreted as like code blocks.

I think this is what was causing the "no language specified" warning.